### PR TITLE
Clarifying edits to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,31 +2,38 @@
 
 This gem packages the jQuery [DataTables](http://datatables.net/) plugin for easy use with the Rails 3.1+ asset pipleine.
 
-It provides all the basic DataTables files, but not (yet) the extras.
+It provides all the basic DataTables files, and a few of the extras.
 
-## Installation
+## General Installation
 
-1. Add `gem 'jquery-datatables-rails'` to the assets group in your Gemfile and run `bundle install`.
-1. Add the JavaScript to `application.js`:
+1. Add to the assets group in your Gemfile:
 
-`//= require dataTables/jquery.dataTables`
+    `gem 'jquery-datatables-rails'`
 
-1. Add the stylesheets to `application.css`:
+1. Install the gem:
 
-`*= require dataTables/jquery.dataTables`
-
-## Twitter Bootstrap 2 support
+    `bundle install`
 
 1. Add the JavaScript to `application.js`:
 
-`//= require dataTables/jquery.dataTables.bootstrap`
+    //= require dataTables/jquery.dataTables
 
-1. Remove the initial stylesheets from `application.css`
 1. Add the stylesheets to `application.css`:
 
-`*= require dataTables/jquery.dataTables.bootstrap`
+    *= require dataTables/jquery.dataTables
 
-1. Initialize your datatables like this:
+## Twitter Bootstrap 2 Installation
+
+1. Complete steps 1-3 of the General Installation
+1. Add the some more JavaScript to `application.js`:
+
+    //= require dataTables/jquery.dataTables.bootstrap
+
+1. Add this (and only this) stylesheet to `application.css`:
+
+    *= require dataTables/jquery.dataTables.bootstrap
+
+1. Initialize your datatables using one of these options:
 
 ```javascript
 // For fluid containers
@@ -34,7 +41,8 @@ $('.datatable').dataTable({
   "sDom": "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>",
   "sPaginationType": "bootstrap"
 });
-
+```
+```javascript
 // For fixed width containers
 $('.datatable').dataTable({
   "sDom": "<'row'<'span6'l><'span6'f>r>t<'row'<'span6'i><'span6'p>>",
@@ -47,14 +55,14 @@ $('.datatable').dataTable({
 Only a few plugins are currently available
 
 * api
-  * fnReloadAjax
-  * fnGetColumnData
+    * fnReloadAjax
+    * fnGetColumnData
 * sorting
-  * numbersHtml
+    * numbersHtml
 * typeDetection
-  * numberHtml
+    * numberHtml
 
-Check out the [assets directory][assets].
+These files can be found in the [assets directory][assets].
 
 ## Extras
 
@@ -65,11 +73,10 @@ Only a few extras are currently available:
 
 To add an extra into your application, include it like follow:
 
-`//= require dataTables/extras/[ExtraName]`
+    //= require dataTables/extras/[ExtraName]
 
 Make sure to also add it's initialization as described on [datatables extras' site][datatables_extras]
 
 
-[assets]: https://github.com/rweng/jquery-datatables-rails/tree/master/vendor/assets/javascripts
-[extras]: https://github.com/rweng/jquery-datatables-rails/tree/master/vendor/assets/javascripts/dataTables/extras
+[assets]: https://github.com/rweng/jquery-datatables-rails/tree/master/vendor/assets/javascripts/dataTables
 [datatables_extras]: http://datatables.net/extras/


### PR DESCRIPTION
Hello! Thanks for maintaining this useful repository.

I hit some issues when i first tried to use it, having never before used jquery-datatables.

My problem was that I had repeatedly misunderstood the instructions in the README. I assumed that the steps under the Twitter Bootstrap section were more or less independent of the installation instructions above. I tried resolving this on a few different days, over the course of a week or so, and every time did not read the instructions properly. Namely, I wasn't including the base js file when I should have been.

Hopefully my edits will clarify this for other people who skim without reading carefully! 

While I was editing the README, I took the opportunity to clean up a few other items as well. Details below.

Thanks again!

—brook r

Commit message:

This is an attempt to make more clear the distinction between a general
installation and a installation for an app with Twitter Bootstrap support.

Also:
- Code blocks are standardized each to their own line for easy copy/paste
- That helps fix the instruction numbering issues
- Some minor rewordings for clarity
- Initialization options set apart a bit to indicate only one is needed
- Modify the link to the plugin files to make it more useful

Hope this helps!
