### PR TITLE
Add support for fnSetFilteringDelay

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ Only a few plugins are currently available
     * fnReloadAjax
     * fnGetColumnData
     * fnFilterOnReturn
+    * fnSetFilteringDelay
 * sorting
     * numbersHtml
 * typeDetection

--- a/vendor/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
+++ b/vendor/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
@@ -1,0 +1,32 @@
+jQuery.fn.dataTableExt.oApi.fnSetFilteringDelay = function ( oSettings, iDelay ) {
+    var _that = this;
+
+    if ( iDelay === undefined ) {
+        iDelay = 250;
+    }
+
+    this.each( function ( i ) {
+        $.fn.dataTableExt.iApiIndex = i;
+        var
+            $this = this,
+            oTimerId = null,
+            sPreviousSearch = null,
+            anControl = $( 'input', _that.fnSettings().aanFeatures.f );
+
+        anControl.unbind( 'keyup' ).bind( 'keyup', function() {
+            var $$this = $this;
+
+            if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
+                window.clearTimeout(oTimerId);
+                sPreviousSearch = anControl.val();
+                oTimerId = window.setTimeout(function() {
+                    $.fn.dataTableExt.iApiIndex = i;
+                    _that.fnFilter( anControl.val() );
+                }, iDelay);
+            }
+        });
+
+        return this;
+    } );
+    return this;
+};


### PR DESCRIPTION
Hi Robin,

I like your jquery-datatables-rails and it works perfect!
Could you please add the support for  [fnSetFilteringDelay](http://datatables.net/plug-ins/api#fnSetFilteringDelay)?
I found it is very useful and we do not need to press enter even when we empty the filter field.

Thanks,
Meidan
