### PR TITLE
CSS fix for TableTools play smoothly with Bootstrap

### DIFF
--- a/vendor/assets/stylesheets/dataTables/jquery.dataTables.bootstrap.css.scss
+++ b/vendor/assets/stylesheets/dataTables/jquery.dataTables.bootstrap.css.scss
@@ -44,3 +44,8 @@ table.dataTable thead .sorting_desc_disabled { background: image-url('dataTables
 table.dataTable th:active {
 	outline: none;
 }
+
+/* fixes for TableTools */
+.DTTT_dropdown {z-index: 2002;}
+
+.DTTT_dropdown li {position: relative;}


### PR DESCRIPTION
The z-index of .dropdown-menu li defaults for 1001 in Twitter Bootstrap. 
This causes .DTTT_collection_background to cover buttons from TableTools plugin.
I've added necessary fixes to make the plugin work with bootstrap using the default configuration from http://datatables.net/release-datatables/extras/TableTools/bootstrap.html
