### PR TITLE
Use Use jQuery.fn.dataTableExt.oPagination.iFullNumbersShowPages

### DIFF
--- a/vendor/assets/javascripts/dataTables/jquery.dataTables.bootstrap.js
+++ b/vendor/assets/javascripts/dataTables/jquery.dataTables.bootstrap.js
@@ -41,7 +41,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
 		},
 
 		"fnUpdate": function ( oSettings, fnDraw ) {
-			var iListLength = 5;
+			var iListLength = jQuery.fn.dataTableExt.oPagination.iFullNumbersShowPages;
 			var oPaging = oSettings.oInstance.fnPagingInfo();
 			var an = oSettings.aanFeatures.p;
 			var i, j, sClass, iStart, iEnd, iHalf=Math.floor(iListLength/2);


### PR DESCRIPTION
Use Use jQuery.fn.dataTableExt.oPagination.iFullNumbersShowPages to configure the number of displayed pages like the "full_numbers" pagination.
