### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,6 +92,10 @@ you to add the following two lines to your `application.css` file:
 
     *= require dataTables/extras/TableTools
     *= require dataTables/extras/TableTools_JUI
+    
+TableTools also requires this to be included in 'application.js':
+    
+    //= require dataTables/extras/ZeroClipboard.js    
 
 Make sure to also add it's initialization as described on [datatables extras' site][datatables_extras]
 


### PR DESCRIPTION
Added that //= require dataTables/extras/ZeroClipboard.js is required in 'application.js' in order for TableTools to work.
