### PR TITLE
Add depend_on_asset for images referenced in SCSS.

### DIFF
--- a/app/assets/javascripts/dataTables/jquery.dataTables.bootstrap3.js
+++ b/app/assets/javascripts/dataTables/jquery.dataTables.bootstrap3.js
@@ -1,13 +1,13 @@
 /* Set the defaults for DataTables initialisation */
 $.extend( true, $.fn.dataTable.defaults, {
-	"sDom": "<'row'<'col-xs-6'l><'col-xs-6'f>r>t<'row'<'col-xs-6'i><'col-xs-6'p>>",
-	"sPaginationType": "bootstrap",
+	"sDom":
+		"<'row'<'col-xs-6'l><'col-xs-6'f>r>"+
+		"t"+
+		"<'row'<'col-xs-6'i><'col-xs-6'p>>",
 	"oLanguage": {
 		"sLengthMenu": "_MENU_ records per page"
 	}
 } );
-
-
 
 
 /* Default class modification */
@@ -17,100 +17,199 @@ $.extend( $.fn.dataTableExt.oStdClasses, {
 	"sLengthSelect": "form-control input-sm"
 } );
 
+// In 1.10 we use the pagination renderers to draw the Bootstrap paging,
+// rather than  custom plug-in
+if ( $.fn.dataTable.Api ) {
+	$.fn.dataTable.defaults.renderer = 'bootstrap';
+	$.fn.dataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, buttons, page, pages ) {
+		var api = new $.fn.dataTable.Api( settings );
+		var classes = settings.oClasses;
+		var lang = settings.oLanguage.oPaginate;
+		var btnDisplay, btnClass;
 
-/* API method to get paging information */
-$.fn.dataTableExt.oApi.fnPagingInfo = function ( oSettings )
-{
-	return {
-		"iStart":         oSettings._iDisplayStart,
-		"iEnd":           oSettings.fnDisplayEnd(),
-		"iLength":        oSettings._iDisplayLength,
-		"iTotal":         oSettings.fnRecordsTotal(),
-		"iFilteredTotal": oSettings.fnRecordsDisplay(),
-		"iPage":          oSettings._iDisplayLength === -1 ?
-			0 : Math.ceil( oSettings._iDisplayStart / oSettings._iDisplayLength ),
-		"iTotalPages":    oSettings._iDisplayLength === -1 ?
-			0 : Math.ceil( oSettings.fnRecordsDisplay() / oSettings._iDisplayLength )
-	};
-};
-
-
-/* Bootstrap style pagination control */
-$.extend( $.fn.dataTableExt.oPagination, {
-	"bootstrap": {
-		"fnInit": function( oSettings, nPaging, fnDraw ) {
-			var oLang = oSettings.oLanguage.oPaginate;
-			var fnClickHandler = function ( e ) {
+		var attach = function( container, buttons ) {
+			var i, ien, node, button;
+			var clickHandler = function ( e ) {
 				e.preventDefault();
-				if ( oSettings.oApi._fnPageChange(oSettings, e.data.action) ) {
-					fnDraw( oSettings );
+				if ( e.data.action !== 'ellipsis' ) {
+					api.page( e.data.action ).draw( false );
 				}
 			};
 
-			$(nPaging).append(
-				'<ul class="pagination">'+
-					'<li class="prev disabled"><a href="#">&larr; '+oLang.sPrevious+'</a></li>'+
-					'<li class="next disabled"><a href="#">'+oLang.sNext+' &rarr; </a></li>'+
-				'</ul>'
-			);
-			var els = $('a', nPaging);
-			$(els[0]).bind( 'click.DT', { action: "previous" }, fnClickHandler );
-			$(els[1]).bind( 'click.DT', { action: "next" }, fnClickHandler );
-		},
+			for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
+				button = buttons[i];
 
-		"fnUpdate": function ( oSettings, fnDraw ) {
-			var iListLength = 5;
-			var oPaging = oSettings.oInstance.fnPagingInfo();
-			var an = oSettings.aanFeatures.p;
-			var i, ien, j, sClass, iStart, iEnd, iHalf=Math.floor(iListLength/2);
+				if ( $.isArray( button ) ) {
+					attach( container, button );
+				}
+				else {
+					btnDisplay = '';
+					btnClass = '';
 
-			if ( oPaging.iTotalPages < iListLength) {
-				iStart = 1;
-				iEnd = oPaging.iTotalPages;
+					switch ( button ) {
+						case 'ellipsis':
+							btnDisplay = '&hellip;';
+							btnClass = 'disabled';
+							break;
+
+						case 'first':
+							btnDisplay = lang.sFirst;
+							btnClass = button + (page > 0 ?
+								'' : ' disabled');
+							break;
+
+						case 'previous':
+							btnDisplay = lang.sPrevious;
+							btnClass = button + (page > 0 ?
+								'' : ' disabled');
+							break;
+
+						case 'next':
+							btnDisplay = lang.sNext;
+							btnClass = button + (page < pages-1 ?
+								'' : ' disabled');
+							break;
+
+						case 'last':
+							btnDisplay = lang.sLast;
+							btnClass = button + (page < pages-1 ?
+								'' : ' disabled');
+							break;
+
+						default:
+							btnDisplay = button + 1;
+							btnClass = page === button ?
+								'active' : '';
+							break;
+					}
+
+					if ( btnDisplay ) {
+						node = $('<li>', {
+								'class': classes.sPageButton+' '+btnClass,
+								'aria-controls': settings.sTableId,
+								'tabindex': settings.iTabIndex,
+								'id': idx === 0 && typeof button === 'string' ?
+									settings.sTableId +'_'+ button :
+									null
+							} )
+							.append( $('<a>', {
+									'href': '#'
+								} )
+								.html( btnDisplay )
+							)
+							.appendTo( container );
+
+						settings.oApi._fnBindAction(
+							node, {action: button}, clickHandler
+						);
+					}
+				}
 			}
-			else if ( oPaging.iPage <= iHalf ) {
-				iStart = 1;
-				iEnd = iListLength;
-			} else if ( oPaging.iPage >= (oPaging.iTotalPages-iHalf) ) {
-				iStart = oPaging.iTotalPages - iListLength + 1;
-				iEnd = oPaging.iTotalPages;
-			} else {
-				iStart = oPaging.iPage - iHalf + 1;
-				iEnd = iStart + iListLength - 1;
-			}
+		};
 
-			for ( i=0, ien=an.length ; i<ien ; i++ ) {
-				// Remove the middle elements
-				$('li:gt(0)', an[i]).filter(':not(:last)').remove();
+		attach(
+			$(host).empty().html('<ul class="pagination"/>').children('ul'),
+			buttons
+		);
+	}
+}
+else {
+	// Integration for 1.9-
+	$.fn.dataTable.defaults.sPaginationType = 'bootstrap';
 
-				// Add the new list items and their event handlers
-				for ( j=iStart ; j<=iEnd ; j++ ) {
-					sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
-					$('<li '+sClass+'><a href="#">'+j+'</a></li>')
-						.insertBefore( $('li:last', an[i])[0] )
-						.bind('click', function (e) {
-							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnDraw( oSettings );
-						} );
+	/* API method to get paging information */
+	$.fn.dataTableExt.oApi.fnPagingInfo = function ( oSettings )
+	{
+		return {
+			"iStart":         oSettings._iDisplayStart,
+			"iEnd":           oSettings.fnDisplayEnd(),
+			"iLength":        oSettings._iDisplayLength,
+			"iTotal":         oSettings.fnRecordsTotal(),
+			"iFilteredTotal": oSettings.fnRecordsDisplay(),
+			"iPage":          oSettings._iDisplayLength === -1 ?
+				0 : Math.ceil( oSettings._iDisplayStart / oSettings._iDisplayLength ),
+			"iTotalPages":    oSettings._iDisplayLength === -1 ?
+				0 : Math.ceil( oSettings.fnRecordsDisplay() / oSettings._iDisplayLength )
+		};
+	};
+
+	/* Bootstrap style pagination control */
+	$.extend( $.fn.dataTableExt.oPagination, {
+		"bootstrap": {
+			"fnInit": function( oSettings, nPaging, fnDraw ) {
+				var oLang = oSettings.oLanguage.oPaginate;
+				var fnClickHandler = function ( e ) {
+					e.preventDefault();
+					if ( oSettings.oApi._fnPageChange(oSettings, e.data.action) ) {
+						fnDraw( oSettings );
+					}
+				};
+
+				$(nPaging).append(
+					'<ul class="pagination">'+
+						'<li class="prev disabled"><a href="#">&larr; '+oLang.sPrevious+'</a></li>'+
+						'<li class="next disabled"><a href="#">'+oLang.sNext+' &rarr; </a></li>'+
+					'</ul>'
+				);
+				var els = $('a', nPaging);
+				$(els[0]).bind( 'click.DT', { action: "previous" }, fnClickHandler );
+				$(els[1]).bind( 'click.DT', { action: "next" }, fnClickHandler );
+			},
+
+			"fnUpdate": function ( oSettings, fnDraw ) {
+				var iListLength = 5;
+				var oPaging = oSettings.oInstance.fnPagingInfo();
+				var an = oSettings.aanFeatures.p;
+				var i, ien, j, sClass, iStart, iEnd, iHalf=Math.floor(iListLength/2);
+
+				if ( oPaging.iTotalPages < iListLength) {
+					iStart = 1;
+					iEnd = oPaging.iTotalPages;
+				}
+				else if ( oPaging.iPage <= iHalf ) {
+					iStart = 1;
+					iEnd = iListLength;
+				} else if ( oPaging.iPage >= (oPaging.iTotalPages-iHalf) ) {
+					iStart = oPaging.iTotalPages - iListLength + 1;
+					iEnd = oPaging.iTotalPages;
+				} else {
+					iStart = oPaging.iPage - iHalf + 1;
+					iEnd = iStart + iListLength - 1;
 				}
 
-				// Add / remove disabled classes from the static elements
-				if ( oPaging.iPage === 0 ) {
-					$('li:first', an[i]).addClass('disabled');
-				} else {
-					$('li:first', an[i]).removeClass('disabled');
-				}
+				for ( i=0, ien=an.length ; i<ien ; i++ ) {
+					// Remove the middle elements
+					$('li:gt(0)', an[i]).filter(':not(:last)').remove();
 
-				if ( oPaging.iPage === oPaging.iTotalPages-1 || oPaging.iTotalPages === 0 ) {
-					$('li:last', an[i]).addClass('disabled');
-				} else {
-					$('li:last', an[i]).removeClass('disabled');
+					// Add the new list items and their event handlers
+					for ( j=iStart ; j<=iEnd ; j++ ) {
+						sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
+						$('<li '+sClass+'><a href="#">'+j+'</a></li>')
+							.insertBefore( $('li:last', an[i])[0] )
+							.bind('click', function (e) {
+								e.preventDefault();
+								oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
+								fnDraw( oSettings );
+							} );
+					}
+
+					// Add / remove disabled classes from the static elements
+					if ( oPaging.iPage === 0 ) {
+						$('li:first', an[i]).addClass('disabled');
+					} else {
+						$('li:first', an[i]).removeClass('disabled');
+					}
+
+					if ( oPaging.iPage === oPaging.iTotalPages-1 || oPaging.iTotalPages === 0 ) {
+						$('li:last', an[i]).addClass('disabled');
+					} else {
+						$('li:last', an[i]).removeClass('disabled');
+					}
 				}
 			}
 		}
-	}
-} );
+	} );
+}
 
 
 /*

--- a/app/assets/stylesheets/dataTables/jquery.dataTables.bootstrap3.css.scss
+++ b/app/assets/stylesheets/dataTables/jquery.dataTables.bootstrap3.css.scss
@@ -33,7 +33,8 @@ div.dataTables_paginate {
 }
 
 div.dataTables_paginate ul.pagination {
-	margin: 2px;
+	margin: 2px 0;
+	white-space: nowrap;
 }
 
 table.dataTable,
@@ -67,6 +68,11 @@ table.dataTable thead .sorting_desc { background: image-url('dataTables/sort_des
 table.dataTable thead .sorting_asc_disabled { background: image-url('dataTables/sort_asc_disabled.png') no-repeat center right; }
 table.dataTable thead .sorting_desc_disabled { background: image-url('dataTables/sort_desc_disabled.png') no-repeat center right; }
 
+table.dataTable thead > tr > th {
+	padding-left: 18px;
+	padding-right: 18px;
+}
+
 table.dataTable th:active {
 	outline: none;
 }
@@ -86,6 +92,7 @@ div.dataTables_scrollHead table thead tr:last-child td:first-child {
 
 div.dataTables_scrollBody table {
 	border-top: none;
+	margin-top: 0 !important;
 	margin-bottom: 0 !important;
 }
 
@@ -95,6 +102,7 @@ div.dataTables_scrollBody tbody tr:first-child td {
 }
 
 div.dataTables_scrollFoot table {
+	margin-top: 0 !important;
 	border-top: none;
 }
 
@@ -188,6 +196,7 @@ div.DTFC_RightHeadWrapper table,
 div.DTFC_RightFootWrapper table,
 table.DTFC_Cloned tr.even {
     background-color: white;
+    margin-bottom: 0;
 }
  
 div.DTFC_RightHeadWrapper table ,
@@ -223,4 +232,3 @@ div.DTFC_RightFootWrapper table,
 div.DTFC_LeftFootWrapper table {
     border-top: none;
 }
-


### PR DESCRIPTION
This prevents better_errors from complaining:

"Asset depends on 'dataTables/sort_both.png' to generate properly but has not declared the dependency"

More information about why this is a good thing here:
https://github.com/schneems/sprockets_better_errors#raise-when-dependencies-improperly-used
