### PR TITLE
Fix incomplete events in filtering delay; fix deprecated bind/unbind usage

### DIFF
--- a/app/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
+++ b/app/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
@@ -13,7 +13,7 @@ jQuery.fn.dataTableExt.oApi.fnSetFilteringDelay = function ( oSettings, iDelay )
             sPreviousSearch = null,
             anControl = $( 'input', _that.fnSettings().aanFeatures.f );
 
-        anControl.unbind( 'keyup' ).bind( 'keyup', function() {
+            anControl.off( 'keyup search input' ).on( 'keyup search input', function() {
             var $$this = $this;
 
             if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {


### PR DESCRIPTION
The events (keyup etc.) need to be updated to match the current version of the plugin with search fields.. I've also replaced bind/unbind with the current jQuery usage of on/off.
