### PR TITLE
Don't attach filter delay unless filtering is present.

### DIFF
--- a/app/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
+++ b/app/assets/javascripts/dataTables/jquery.dataTables.api.fnSetFilteringDelay.js
@@ -7,24 +7,27 @@ jQuery.fn.dataTableExt.oApi.fnSetFilteringDelay = function ( oSettings, iDelay )
 
     this.each( function ( i ) {
         $.fn.dataTableExt.iApiIndex = i;
-        var
-            $this = this,
-            oTimerId = null,
-            sPreviousSearch = null,
-            anControl = $( 'input', _that.fnSettings().aanFeatures.f );
+        var aanFeatures = _that.fnSettings().aanFeatures;
+        if (aanFeatures.f) {
+            var
+                $this = this,
+                oTimerId = null,
+                sPreviousSearch = null,
+                anControl = $( 'input',  aanFeatures.f );
 
             anControl.off( 'keyup search input' ).on( 'keyup search input', function() {
-            var $$this = $this;
+                var $$this = $this;
 
-            if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
-                window.clearTimeout(oTimerId);
-                sPreviousSearch = anControl.val();
-                oTimerId = window.setTimeout(function() {
-                    $.fn.dataTableExt.iApiIndex = i;
-                    _that.fnFilter( anControl.val() );
-                }, iDelay);
-            }
-        });
+                if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
+                    window.clearTimeout(oTimerId);
+                    sPreviousSearch = anControl.val();
+                    oTimerId = window.setTimeout(function() {
+                        $.fn.dataTableExt.iApiIndex = i;
+                        _that.fnFilter( anControl.val() );
+                    }, iDelay);
+                }
+            });
+        }
 
         return this;
     } );


### PR DESCRIPTION
This avoids accidentally binding to random inputs on the page and breaking things. Yes, it's true that you should just not activate the filter delay unless you've got filtering enabled, but in the interest of the best possible default experience, that shouldn't cause side effects.

Alternatively we could throw an exception if the filter input isn't available. Let me know if you'd prefer that approach.
