### PR TITLE
Made DataTable layout independent of Bootstrap's grid column count

### DIFF
--- a/app/assets/javascripts/dataTables/bootstrap/3/jquery.dataTables.bootstrap.js
+++ b/app/assets/javascripts/dataTables/bootstrap/3/jquery.dataTables.bootstrap.js
@@ -19,9 +19,9 @@ var factory = function( $, DataTable ) {
 /* Set the defaults for DataTables initialisation */
 $.extend( true, DataTable.defaults, {
 	dom:
-		"<'row'<'col-xs-6'l><'col-xs-6'f>r>"+
+		"<'row'<'col-50-percent'l><'col-50-percent'f>r>"+
 		"t"+
-		"<'row'<'col-xs-6'i><'col-xs-6'p>>",
+		"<'row'<'col-50-percent'i><'col-50-percent'p>>",
 	renderer: 'bootstrap'
 } );
 

--- a/app/assets/stylesheets/dataTables/bootstrap/3/jquery.dataTables.bootstrap.css.scss
+++ b/app/assets/stylesheets/dataTables/bootstrap/3/jquery.dataTables.bootstrap.css.scss
@@ -278,3 +278,13 @@ div.DTFC_LeftFootWrapper table {
 div.FixedHeader_Cloned table {
 	margin: 0 !important
 }
+
+
+/*
+ * 50% wide column
+ */
+div.row .col-50-percent {
+	width: 50%;
+	padding: 0px 15px 0px 15px;
+	float: left;
+}


### PR DESCRIPTION
For our project we're using a customized version of Twitter's Bootstrap (http://getbootstrap.com/customize/). For better UI handling we changed the grid column count (@grid-columns) from 12 to 60 (which is quite common). The DataTables use the hard coded .col-xs-6 style for creating a 50% wide column - which breaks the layout for customized Bootstraps.

With this pull request the columns are created independently of the total grid column count.