### PR TITLE
remove debug output

### DIFF
--- a/app/assets/javascripts/dataTables/extras/dataTables.responsive.js
+++ b/app/assets/javascripts/dataTables/extras/dataTables.responsive.js
@@ -833,8 +833,6 @@ $(document).on( 'init.dt.dtr', function (e, settings, json) {
 		 settings.oInit.responsive ||
 		 DataTable.defaults.responsive
 	) {
-		console.log( e.namespace );
-
 		var init = settings.oInit.responsive;
 
 		if ( init !== false ) {


### PR DESCRIPTION
Just remove a line of output, causing an annoying `dt` to be printed repeatedly when running test.
See
```
$ rspec
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 43245
............................dt
dt
.dt
dt
...........................

[...]

```