### PR TITLE
Add license flag to the gemspec

### DIFF
--- a/jquery-datatables-rails.gemspec
+++ b/jquery-datatables-rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/rweng/jquery-datatables-rails"
   s.summary = %q{jquery datatables for rails}
   s.description = %q{}
+  s.license = 'MIT'
 
   s.files = `git ls-files`.split("\n")
   s.files = Dir["{app,lib,vendor}/**/*"]


### PR DESCRIPTION
I picked the MIT license, as the LICENSE file looks like MIT.
I would like to add this because it will make automated license checking using [dblock/gem-license](https://github.com/dblock/gem-licenses) easier.